### PR TITLE
Added custom feature to allow combat bracket checking in wilderness

### DIFF
--- a/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmConfig.java
+++ b/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmConfig.java
@@ -55,12 +55,20 @@ public interface WildernessPlayerAlarmConfig extends Config
 		return true;
 	}
 
+	@ConfigItem(
+			keyName = "combatCheck",
+			name = "Ignore outside combat bracket",
+			description = "Do not alarm for players outside your combat bracket",
+			position = 4
+	)
+	default boolean combatCheck() { return false; }
+
 	@Alpha
 	@ConfigItem(
 			keyName = "flashColor",
 			name = "Flash color",
 			description = "Sets the color of the alarm flashes",
-			position = 4
+			position = 5
 	)
 	default Color flashColor()
 	{

--- a/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmPlugin.java
+++ b/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmPlugin.java
@@ -2,6 +2,8 @@ package com.WildernessPlayerAlarm;
 
 import com.google.inject.Provides;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -9,6 +11,8 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.ClientTick;
 import net.runelite.api.Player;
 import net.runelite.api.Varbits;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.Notifier;
@@ -19,7 +23,7 @@ import net.runelite.client.ui.overlay.OverlayManager;
 
 @Slf4j
 @PluginDescriptor(
-	name = "Wilderness Player Alarm"
+		name = "Wilderness Player Alarm"
 )
 public class WildernessPlayerAlarmPlugin extends Plugin
 {
@@ -54,6 +58,10 @@ public class WildernessPlayerAlarmPlugin extends Plugin
 				if (player.getId() != self.getId() && (player.getLocalLocation().distanceTo(currentPosition) / 128) <= config.alarmRadius())
 				{
 					shouldAlarm = true;
+
+					if (config.combatCheck() && !combatCheck(player)) {
+						shouldAlarm = false;
+					}
 					if (config.ignoreClan() && player.isClanMember()){
 						shouldAlarm = false;
 					}
@@ -78,6 +86,37 @@ public class WildernessPlayerAlarmPlugin extends Plugin
 			overlayOn = false;
 			overlayManager.remove(overlay);
 		}
+	}
+
+	private boolean combatCheck(Player player)
+	{
+		String wildernessLevel = null;
+		int maxCombat = 0;
+		int minCombat = 0;
+
+		Widget wildernessLevelWidget = client.getWidget(WidgetInfo.PVP_WILDERNESS_LEVEL);
+
+		if (wildernessLevelWidget != null && !wildernessLevelWidget.isHidden())
+		{
+			wildernessLevel = wildernessLevelWidget.getText();
+		}
+
+		Pattern pattern = Pattern.compile("\\d+-\\d+");
+		Matcher matcher = pattern.matcher(wildernessLevel);
+
+		if (matcher.find())
+		{
+			String[] numbers = matcher.group(0).split("-");
+			minCombat = Integer.parseInt(numbers[0]);
+			maxCombat = Integer.parseInt(numbers[1]);
+		}
+
+		if (player.getCombatLevel() >= minCombat && player.getCombatLevel() <= maxCombat)
+		{
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
Created a config option to allow the user to only see alarms for players within their combat bracket in the current wilderness.