### PR TITLE
Add a few QoL features

### DIFF
--- a/src/main/java/com/WildernessPlayerAlarm/AlarmOverlay.java
+++ b/src/main/java/com/WildernessPlayerAlarm/AlarmOverlay.java
@@ -17,11 +17,7 @@ public class AlarmOverlay extends OverlayPanel
     {
         this.config = config;
         this.client = client;
-    }
 
-    @Override
-    public Dimension render(Graphics2D graphics)
-    {
         panelComponent.getChildren().clear();
         panelComponent.setPreferredSize(new Dimension(client.getCanvasWidth(), client.getCanvasHeight()));
         for(int i = 0; i < 100; ++i)
@@ -30,7 +26,12 @@ public class AlarmOverlay extends OverlayPanel
                     .left(" ")
                     .build());
         }
-        if (client.getGameCycle() % 20 >= 10)
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics)
+    {
+        if (config.enableFlash() && client.getGameCycle() % 20 >= 10)
         {
             panelComponent.setBackgroundColor(config.flashColor());
         } else

--- a/src/main/java/com/WildernessPlayerAlarm/SilencedState.java
+++ b/src/main/java/com/WildernessPlayerAlarm/SilencedState.java
@@ -1,0 +1,50 @@
+package com.WildernessPlayerAlarm;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Tracks the state of a user-requested alarm silence
+ */
+public class SilencedState {
+    public boolean isSilenced;
+    public Set<Integer> playerIdsAtTimeOfSilence;
+
+    public SilencedState() {
+        this.isSilenced = false;
+        this.playerIdsAtTimeOfSilence = Collections.checkedSet(new HashSet<>(), Integer.class);
+    }
+
+    /**
+     * Updates the silence based on the current surrounding players, and returns whether the silence is still
+     * in effect.
+     */
+    public boolean updateAndCheck(Set<Integer> currentlyOffendingPlayers) {
+        if (!isSilenced) {
+            return false;
+        }
+
+        if (playerIdsAtTimeOfSilence.containsAll(currentlyOffendingPlayers)) {
+            playerIdsAtTimeOfSilence.retainAll(currentlyOffendingPlayers);
+            return true;
+        }
+
+        // There's been a new player after the silence, cancel silence to notify user of change.
+        isSilenced = false;
+        playerIdsAtTimeOfSilence.clear();
+        return false;
+    }
+
+    public void silence(Set<Integer> currentlyOffendingPlayers) {
+        playerIdsAtTimeOfSilence.clear();
+        if (currentlyOffendingPlayers.isEmpty()) {
+            // If nothing is currently triggering the alarm, then silencing has no meaning.
+            isSilenced = false;
+            return;
+        }
+
+        isSilenced = true;
+        playerIdsAtTimeOfSilence.addAll(currentlyOffendingPlayers);
+    }
+}

--- a/src/main/java/com/WildernessPlayerAlarm/WildernessCombatRange.java
+++ b/src/main/java/com/WildernessPlayerAlarm/WildernessCombatRange.java
@@ -1,0 +1,64 @@
+package com.WildernessPlayerAlarm;
+
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.api.WorldType;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class WildernessCombatRange {
+    private static final Pattern WILDERNESS_LEVEL_PATTERN = Pattern.compile("^Level: (\\d+).*");
+
+    private final boolean isPlayerInWilderness;
+    private final int wildernessLevel;
+    private final int playerLevel;
+
+    private WildernessCombatRange() {
+        this.isPlayerInWilderness = false;
+        this.wildernessLevel = 0;
+        this.playerLevel = 0;
+    }
+
+    private WildernessCombatRange(int wildernessLevel, int playerLevel) {
+        this.isPlayerInWilderness = true;
+        this.wildernessLevel = wildernessLevel;
+        this.playerLevel = playerLevel;
+    }
+
+    public boolean isOtherPlayerInCombatRange(Player otherPlayer) {
+        if (!isPlayerInWilderness) {
+            return false;
+        }
+        int otherPlayerCombatLevel = otherPlayer.getCombatLevel();
+        return otherPlayerCombatLevel >= (playerLevel - wildernessLevel)
+                && otherPlayerCombatLevel <= (playerLevel + wildernessLevel);
+    }
+
+    /**
+     * Parses the attack range from the wilderness level widget. This feels fragile, but appears to be the de-facto
+     * way of getting this information based on the official CombatLevel plugin.
+     */
+    public static WildernessCombatRange getCurrentCombatRange(Client client) {
+        final Widget wildernessLevelWidget = client.getWidget(WidgetInfo.PVP_WILDERNESS_LEVEL);
+        if (wildernessLevelWidget == null)
+        {
+            return new WildernessCombatRange();
+        }
+
+        final String wildernessLevelText = wildernessLevelWidget.getText();
+        final Matcher m = WILDERNESS_LEVEL_PATTERN.matcher(wildernessLevelText);
+        if (!m.matches() || WorldType.isPvpWorld(client.getWorldType()))
+        {
+            return new WildernessCombatRange();
+        }
+
+        final int wildernessLevel = Integer.parseInt(m.group(1));
+        final int combatLevel = client.getLocalPlayer().getCombatLevel();
+        return new WildernessCombatRange(wildernessLevel, combatLevel);
+    }
+}

--- a/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmConfig.java
+++ b/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmConfig.java
@@ -56,10 +56,21 @@ public interface WildernessPlayerAlarmConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "ignorePlayersOutsideCombatRange",
+			name = "Ignore players outside combat range",
+			description = "Do not alarm for players who cannot attack you at the current wilderness level.",
+			position = 4
+	)
+	default boolean ignorePlayersOutsideCombatRange()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 			keyName = "enableFlash",
 			name = "Enable flash",
 			description = "Enables screen flashing when a player is in range.",
-			position = 4
+			position = 5
 	)
 	default boolean enableFlash()
 	{
@@ -71,7 +82,7 @@ public interface WildernessPlayerAlarmConfig extends Config
 			keyName = "flashColor",
 			name = "Flash color",
 			description = "Sets the color of the alarm flashes",
-			position = 5
+			position = 6
 	)
 	default Color flashColor()
 	{

--- a/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmConfig.java
+++ b/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmConfig.java
@@ -89,4 +89,13 @@ public interface WildernessPlayerAlarmConfig extends Config
 		return new Color(255, 255, 0, 70);
 	}
 
+	@ConfigItem(
+			keyName = "silenceKey",
+			name = "Hotkey for silencing flash",
+			description = "Removes flash from screen until a new eligible player enters the alert range.",
+			position = 7
+	)
+	default Keybind silenceKey() {
+		return Keybind.NOT_SET;
+	}
 }

--- a/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmConfig.java
+++ b/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmConfig.java
@@ -55,12 +55,23 @@ public interface WildernessPlayerAlarmConfig extends Config
 		return true;
 	}
 
+	@ConfigItem(
+			keyName = "enableFlash",
+			name = "Enable flash",
+			description = "Enables screen flashing when a player is in range.",
+			position = 4
+	)
+	default boolean enableFlash()
+	{
+		return true;
+	}
+
 	@Alpha
 	@ConfigItem(
 			keyName = "flashColor",
 			name = "Flash color",
 			description = "Sets the color of the alarm flashes",
-			position = 4
+			position = 5
 	)
 	default Color flashColor()
 	{

--- a/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmPlugin.java
+++ b/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmPlugin.java
@@ -1,7 +1,11 @@
 package com.WildernessPlayerAlarm;
 
 import com.google.inject.Provides;
+
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -12,9 +16,11 @@ import net.runelite.api.Varbits;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.Notifier;
+import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.HotkeyListener;
 
 
 @Slf4j
@@ -36,22 +42,38 @@ public class WildernessPlayerAlarmPlugin extends Plugin
 	private AlarmOverlay overlay;
 
 	@Inject
+	private KeyManager keyManager;
+
+	@Inject
 	private Notifier notifier;
 
+	@Inject
+	private SilencedState silencedState;
+
 	private boolean overlayOn = false;
+	private final Set<Integer> currentlyOffendingPlayers = Collections.checkedSet(new HashSet<>(), Integer.class);
+
+
+	@Override
+	protected void startUp() throws Exception {
+		keyManager.registerKeyListener(new HotkeyListener(() -> config.silenceKey()) {
+			@Override
+			public void hotkeyPressed() {
+				silencedState.silence(currentlyOffendingPlayers);
+			}
+		});
+	}
 
 	@Subscribe
 	public void onClientTick(ClientTick clientTick) {
 		List<Player> players = client.getPlayers();
-		boolean shouldAlarm = false;
+		currentlyOffendingPlayers.clear();
 		Player self = client.getLocalPlayer();
 		LocalPoint currentPosition = client.getLocalPlayer().getLocalLocation();
 		WildernessCombatRange combatRange = WildernessCombatRange.getCurrentCombatRange(client);
-
 		if (client.getVarbitValue(Varbits.IN_WILDERNESS) == 1)
 		{
 			for (Player player : players) {
-
 				if (player.getId() != self.getId() && (player.getLocalLocation().distanceTo(currentPosition) / 128) <= config.alarmRadius())
 				{
 					if (config.ignoreClan() && player.isClanMember()){
@@ -63,24 +85,23 @@ public class WildernessPlayerAlarmPlugin extends Plugin
 					if (config.ignorePlayersOutsideCombatRange() && !combatRange.isOtherPlayerInCombatRange(player)) {
 						continue;
 					}
-					shouldAlarm = true;
+					currentlyOffendingPlayers.add(player.getId());
 				}
 
 			}
 		}
 
-		if (shouldAlarm && !overlayOn)
+		if (currentlyOffendingPlayers.isEmpty() || silencedState.updateAndCheck(currentlyOffendingPlayers))
+		{
+			overlayOn = false;
+			overlayManager.remove(overlay);
+		} else if (!overlayOn)
 		{
 			if (config.desktopNotification()){
 				notifier.notify("Player spotted!");
 			}
 			overlayOn = true;
 			overlayManager.add(overlay);
-		}
-		if (!shouldAlarm)
-		{
-			overlayOn = false;
-			overlayManager.remove(overlay);
 		}
 	}
 

--- a/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmPlugin.java
+++ b/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmPlugin.java
@@ -53,13 +53,13 @@ public class WildernessPlayerAlarmPlugin extends Plugin
 
 				if (player.getId() != self.getId() && (player.getLocalLocation().distanceTo(currentPosition) / 128) <= config.alarmRadius())
 				{
-					shouldAlarm = true;
 					if (config.ignoreClan() && player.isClanMember()){
-						shouldAlarm = false;
+						continue;
 					}
 					if (config.ignoreFriends() && player.isFriend()){
-						shouldAlarm = false;
+						continue;
 					}
+					shouldAlarm = true;
 				}
 
 			}

--- a/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmPlugin.java
+++ b/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmPlugin.java
@@ -46,6 +46,7 @@ public class WildernessPlayerAlarmPlugin extends Plugin
 		boolean shouldAlarm = false;
 		Player self = client.getLocalPlayer();
 		LocalPoint currentPosition = client.getLocalPlayer().getLocalLocation();
+		WildernessCombatRange combatRange = WildernessCombatRange.getCurrentCombatRange(client);
 
 		if (client.getVarbitValue(Varbits.IN_WILDERNESS) == 1)
 		{
@@ -57,6 +58,9 @@ public class WildernessPlayerAlarmPlugin extends Plugin
 						continue;
 					}
 					if (config.ignoreFriends() && player.isFriend()){
+						continue;
+					}
+					if (config.ignorePlayersOutsideCombatRange() && !combatRange.isOtherPlayerInCombatRange(player)) {
 						continue;
 					}
 					shouldAlarm = true;


### PR DESCRIPTION
 - Option to disable flash (note this is currently possible by changing the overlay color to transparent, but it's clear from the repo issues that this option is not very obvious to users)
 - Fix a bug where ignored members can invalidate the warning even if other players are nearby
 - Add an option to ignore players who could not PK you a the current wildy level
 - Add a "Silence" hotkey, which silences the alarm until a new player enters your alarm range.