### PR TITLE
Add `No PvP` for Deadman Mode

### DIFF
--- a/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmPlugin.java
+++ b/src/main/java/com/WildernessPlayerAlarm/WildernessPlayerAlarmPlugin.java
@@ -174,6 +174,7 @@ public class WildernessPlayerAlarmPlugin extends Plugin {
     String widgetText = widget.getText();
     pvp &= !widgetText.startsWith("Protection");
     pvp &= !widgetText.startsWith("Guarded");
+    pvp &= !widgetText.startsWith("No PvP");
     return pvp;
   }
 


### PR DESCRIPTION
In Deadman Mode, I think (but don't have evidence) it will flash in no-PvP areas, such as random events and underwater if I recall.

<img width="48" height="47" alt="image" src="https://github.com/user-attachments/assets/20dbfbf0-820d-40fc-bc52-80b7b17b40ae" />

So I've added that in. It's not the perfect solution, as the plugin will still flash in Pest Control due to only checking the string instead of the icon.

<img width="60" height="56" alt="image" src="https://github.com/user-attachments/assets/fc06370e-8af3-4ac0-a40d-5bb0fd7fe63c" /><br><img width="345" height="20" alt="image" src="https://github.com/user-attachments/assets/577a9110-ec23-476a-8a45-b1632c7e66c6" />

